### PR TITLE
Rationalize fallback to TCP login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # iscsi-rdma-boot
 
 A set of initramfs scripts that disables the open-iscsi boot scripts (at runtime) and attempts to log in to the previously configured target using iSER.
-If iSER is not available, this will silently fail and log in using TCP as of now.
+If iSER is not available (if ibstat detects no RDMA-capable devices), this will fall back to TCP to still allow booting.
 
 iscsid is also left running from the initramfs. This is not ideal and I need to fix this.
 

--- a/iscsi-rdma-root/DEBIAN/control
+++ b/iscsi-rdma-root/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0
 Section: admin
 Priority: optional
 Architecture: all
-Depends: rdma-core, open-iscsi
+Depends: rdma-core, open-iscsi, infiniband-diags
 Maintainer: Charlie Camilleri <charlie@i-am.cool>
 Description: iSER root scripts
  Piggyback off open-iscsi initramfs scripts to log 


### PR DESCRIPTION
- Add dependency for infiniband-diags (ibstat)
- Change README to reflect this